### PR TITLE
V1 support for identify calls

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,38 @@
+{
+  "requireSpaceAfterKeywords": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "switch",
+    "return",
+    "try",
+    "catch"
+  ],
+  "requireParenthesesAroundIIFE": true,
+  "disallowSpacesInFunctionExpression": {
+    "beforeOpeningRoundBrace": true,
+    "beforeOpeningCurlyBrace": true
+  },
+  "disallowSpacesInFunctionExpression": {
+    "beforeOpeningRoundBrace": true,
+    "beforeOpeningCurlyBrace": true
+  },
+  "disallowSpacesInsideArrayBrackets": true,
+  "disallowSpacesInsideParentheses": true,
+  "requireSpacesInsideObjectBrackets": "allButNested",
+  "disallowQuotedKeysInObjects": "allButReserved",
+  "disallowSpaceAfterObjectKeys": true,
+  "requireCommaBeforeLineBreak": true,
+  "disallowMultipleLineStrings": true,
+  "disallowMultipleLineBreaks": true,
+  "disallowMixedSpacesAndTabs": true,
+  "disallowTrailingWhitespace": true,
+  "disallowKeywordsOnNewLine": ["else"],
+  "requireDotNotation": true,
+  "validateJSDoc": {
+    "checkParamNames": true,
+    "checkRedundantParams": true,
+    "requireParamTypes": true
+  }
+}

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -16,11 +16,9 @@ var reject = require('reject');
 exports.identify = function(identify){
 
   var payload = {};
-  payload.username = identify.userId() || identify.username();
+  payload.username = identify.username() || identify.userId();
   payload.user_email = identify.email();
   payload.event = 'start';
-
-  var context = identify.context();
 
   payload.dev_id = identify.proxy('context.device.id');
   payload.dev_name = identify.proxy('context.device.model');
@@ -28,6 +26,8 @@ exports.identify = function(identify){
   payload.app_ver = identify.proxy('context.app.version');
   payload.os_name = identify.proxy('context.os.name');
   payload.os_version = identify.proxy('context.os.version');
+
+  payload.user_info = identify.traits();
 
   return reject(payload);
 };

--- a/test/fixtures/identify-basic.json
+++ b/test/fixtures/identify-basic.json
@@ -42,6 +42,12 @@
     "dev_id": "some-device",
     "username": "user-id",
     "user_email": "jd@example.com",
+    "user_info": {
+      "email": "jd@example.com",
+      "firstName": "John",
+      "lastName": "Doe",
+      "id": "user-id"
+    },
     "event": "start",
     "app_name": "Test",
     "app_ver": "1.0",


### PR DESCRIPTION
@harrietgrace @ndhoule 

Kahuna SS integration. We agreed with Rdio for a v1 to support only the identify call to send user registration events. V2 down the line will support behavorial events. Before we implement that though, Kahuna has some work to do on their end- in their Android SDK they have a trackEvent method, but not on the server-side. Ideally we'd like to keep the bundled and server-side integrations as close as possible. 
