### PR TITLE
Fix identify track

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -4,9 +4,13 @@
 
 var reject = require('reject');
 var hash = require('string-hash');
+var unixTime = require('unix-time');
+var foldl = require('@ndhoule/foldl');
 
 /**
  * Map identify.
+ *
+ * https://app.usekahuna.com/tap/public_docs/Content/APIs/Server.htm#UserCredentialParameters
  *
  * @param {Identify} identify
  * @param {Object} settings
@@ -15,18 +19,20 @@ var hash = require('string-hash');
  */
 
 exports.identify = function(identify){
+  var traits = identify.traits();
   var payload = {
     event: 'start',
-    username: identify.username(),
-    user_id: identify.userId(),
-    user_info: JSON.stringify(identify.traits())
+    user_info: JSON.stringify(traits),
   };
+  payload.credentials = formulateCreds(identify);
 
-  return decorate(identify, payload);
+  return addDeviceParams(identify, payload);
 };
 
 /**
  * Map track
+ *
+ * https://app.usekahuna.com/tap/public_docs/Content/APIs/Server.htm#Intelligent_Event_Request
  *
  * @param {Track} track
  * @param {Object} settings
@@ -35,27 +41,34 @@ exports.identify = function(identify){
  */
 
 exports.track = function(track){
-  var payload = {
-    event: track.event(),
-    user_id: track.userId()
-  };
-
+  var payload = {};
   var traits = track.proxy('context.traits');
-
-  // if user did not provide traits manually on client, this may be _undesired_,
-  // but we have no way to really enforce this since the server doesn't
-  // technically require these fields
-  if (traits) {
-    delete traits.id;
+  if (traits && !isEmpty(traits)) {
+    traits.id = track.userId(); // add traits.id for parity with identify.traits()
     payload.user_info = JSON.stringify(traits);
-    payload.username = traits.username;
   }
+  var events = [{
+    event: track.event(),
+    time: unixTime(track.timestamp())
+  }];
 
-  return decorate(track, payload);
+  // Formulate properties to required specs
+  // TODO handle nested objects and arrays
+  events[0].properties = foldl(function(results, value, key){
+    results[key] = [value];
+    return results;
+  }, {}, track.properties());
+
+  payload.events = JSON.stringify(events);
+  payload.credentials = formulateCreds(track);
+
+  return addDeviceParams(track, payload);
 };
 
 /**
  * Augments the `payload` with common fields, returns a cleaned-up object.
+ *
+ * https://app.usekahuna.com/tap/public_docs/Content/APIs/Server.htm#DeviceParameters
  *
  * @param {Facade} facade
  * @param {Object} payload
@@ -63,10 +76,7 @@ exports.track = function(track){
  * @api private
  */
 
-function decorate(facade, payload) {
-  // user props
-  payload.user_email = facade.email();
-
+function addDeviceParams(facade, payload) {
   // device props
   payload.dev_id = getOrGenerateDevId(facade, payload);
   payload.dev_name = facade.proxy('context.device.model');
@@ -97,17 +107,63 @@ function decorate(facade, payload) {
   return reject(payload);
 }
 
+/**
+ * Formulate credential payload
+ *
+ * @param {Object} facade
+ * @return {Object}
+ * @api private
+ */
+
+function formulateCreds(facade){
+  var credentials = {
+    user_id: facade.userId(),
+    email: facade.email(),
+    username: facade.username()
+  }
+
+  // track.username falls back on userId while identify.username does not.
+  // Stay consistent by removing duplicate username
+  if (facade.username() && facade.username() == facade.userId()) delete credentials.username;
+
+  return JSON.stringify(reject(credentials));
+}
+
+/**
+ * Get the DeviceId or Generate one
+ *
+ * @param {Object} facade
+ * @param {Object} payload
+ *
+ * @return {String}
+ * @api private
+ */
+
 function getOrGenerateDevId(facade, payload) {
     var devId = facade.proxy('context.device.id');
     if (devId && devId.length > 0) {
       return devId;
     }
-    if (payload.user_id) {
-      devId = "nodev-segment-user-id-" + hash(payload.user_id);
-    } else if (payload.username) {
-      devId = "nodev-segment-" + hash(payload.username);
-    } else if (payload.user_email) {
-      devId = "nodev-segment-" + hash(payload.user_email);
+    if (facade.userId()) {
+      devId = "nodev-segment-user-id-" + hash(facade.userId());
+    } else if (facade.username()) {
+      devId = "nodev-segment-" + hash(facade.username());
+    } else if (facade.email()) {
+      devId = "nodev-segment-" + hash(facade.email());
     }
+
     return devId;
+}
+
+/**
+ * Check if object is empty
+ *
+ * @param {Object} obj
+ *
+ * @return {Boolean}
+ * @api private
+ */
+
+function isEmpty(obj) {
+  return Object.keys(obj).length === 0 && JSON.stringify(obj) === JSON.stringify({});
 }

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -21,7 +21,7 @@ var foldl = require('@ndhoule/foldl');
 exports.identify = function(identify){
   var traits = identify.traits();
   var payload = {
-    event: 'start',
+    event: 'user_created_or_updated_segment', // Asked by Kahuna
     user_info: JSON.stringify(traits),
   };
   payload.credentials = formulateCreds(identify);
@@ -42,9 +42,10 @@ exports.identify = function(identify){
 
 exports.track = function(track){
   var payload = {};
+  // Some track events that are campaign critical inside Kahuna may depend on user attributes
   var traits = track.proxy('context.traits');
   if (traits && !isEmpty(traits)) {
-    traits.id = track.userId(); // add traits.id for parity with identify.traits()
+    traits.id = track.userId(); // adding traits.id for parity with identify.traits()
     payload.user_info = JSON.stringify(traits);
   }
   var events = [{
@@ -118,19 +119,16 @@ function addDeviceParams(facade, payload) {
 function formulateCreds(facade){
   var credentials = {
     user_id: facade.userId(),
-    email: facade.email(),
-    username: facade.username()
+    email: facade.email()
   }
-
-  // track.username falls back on userId while identify.username does not.
-  // Stay consistent by removing duplicate username
-  if (facade.username() && facade.username() == facade.userId()) delete credentials.username;
 
   return JSON.stringify(reject(credentials));
 }
 
 /**
  * Get the DeviceId or Generate one
+ *
+ * Necessary incase they are only sending `user_id` and no email
  *
  * @param {Object} facade
  * @param {Object} payload

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "test": "make test"
   },
   "dependencies": {
+    "@ndhoule/foldl": "^1.0.3",
     "reject": "0.0.1",
     "segmentio-integration": "^3.0.5",
-    "string-hash": "1.1.0"
+    "string-hash": "1.1.0",
+    "unix-time": "^1.0.1"
   },
   "devDependencies": {
     "istanbul": "0.x",

--- a/test/fixtures/identify-basic.json
+++ b/test/fixtures/identify-basic.json
@@ -41,9 +41,9 @@
   },
   "output": {
     "dev_id": "999999",
-    "credentials": "{\"user_id\":\"111\",\"email\":\"bulgogi@bulgogi.com\",\"username\":\"food\"}",
+    "credentials": "{\"user_id\":\"111\",\"email\":\"bulgogi@bulgogi.com\"}",
     "user_info": "{\"firstName\":\"Han\",\"lastName\":\"Kim\",\"email\":\"bulgogi@bulgogi.com\",\"username\":\"food\",\"id\":\"111\"}",
-    "event": "start",
+    "event": "user_created_or_updated_segment",
     "app_name": "Test",
     "app_ver": "1.0",
     "os_name": "android",

--- a/test/fixtures/identify-basic.json
+++ b/test/fixtures/identify-basic.json
@@ -1,12 +1,12 @@
 {
   "input": {
     "type": "identify",
-    "userId": "user-id2",
+    "userId": "111",
     "traits": {
-      "firstName": "Jane",
-      "lastName": "Doe",
-      "email": "janedoe@example.com",
-      "username": "janedoe23"
+      "firstName": "Han",
+      "lastName": "Kim",
+      "email": "bulgogi@bulgogi.com",
+      "username": "food"
     },
     "context": {
       "ip": "10.0.0.2",
@@ -19,7 +19,7 @@
         "model": "1.2",
         "manufacturer": "some-brand",
         "advertisingId": "id-for-attribution",
-        "id": "some-device"
+        "id": "999999"
       },
       "os": {
         "name": "Android",
@@ -40,11 +40,9 @@
     }
   },
   "output": {
-    "dev_id": "some-device",
-    "user_id": "user-id2",
-    "user_email": "janedoe@example.com",
-    "user_info": "{\"firstName\":\"Jane\",\"lastName\":\"Doe\",\"email\":\"janedoe@example.com\",\"username\":\"janedoe23\",\"id\":\"user-id2\"}",
-    "username": "janedoe23",
+    "dev_id": "999999",
+    "credentials": "{\"user_id\":\"111\",\"email\":\"bulgogi@bulgogi.com\",\"username\":\"food\"}",
+    "user_info": "{\"firstName\":\"Han\",\"lastName\":\"Kim\",\"email\":\"bulgogi@bulgogi.com\",\"username\":\"food\",\"id\":\"111\"}",
     "event": "start",
     "app_name": "Test",
     "app_ver": "1.0",

--- a/test/fixtures/identify-no-dev-id.json
+++ b/test/fixtures/identify-no-dev-id.json
@@ -1,11 +1,11 @@
 {
   "input": {
     "type": "identify",
-    "userId": "user-id2",
+    "userId": "100",
     "traits": {
-      "firstName": "Jane",
-      "lastName": "Doe",
-      "email": "janedoe@example.com"
+      "firstName": "Rick",
+      "lastName": "Morty",
+      "email": "hagrid@hagrid.com"
     },
     "context": {
       "ip": "10.0.0.2",
@@ -38,10 +38,9 @@
     }
   },
   "output": {
-    "dev_id": "nodev-segment-user-id-2964295494",
-    "user_id": "user-id2",
-    "user_email": "janedoe@example.com",
-    "user_info": "{\"firstName\":\"Jane\",\"lastName\":\"Doe\",\"email\":\"janedoe@example.com\",\"id\":\"user-id2\"}",
+    "dev_id": "nodev-segment-user-id-193357972",
+    "credentials": "{\"user_id\":\"100\",\"email\":\"hagrid@hagrid.com\"}",
+    "user_info": "{\"firstName\":\"Rick\",\"lastName\":\"Morty\",\"email\":\"hagrid@hagrid.com\",\"id\":\"100\"}",
     "event": "start",
     "app_name": "Test",
     "app_ver": "1.0",

--- a/test/fixtures/identify-no-dev-id.json
+++ b/test/fixtures/identify-no-dev-id.json
@@ -41,7 +41,7 @@
     "dev_id": "nodev-segment-user-id-193357972",
     "credentials": "{\"user_id\":\"100\",\"email\":\"hagrid@hagrid.com\"}",
     "user_info": "{\"firstName\":\"Rick\",\"lastName\":\"Morty\",\"email\":\"hagrid@hagrid.com\",\"id\":\"100\"}",
-    "event": "start",
+    "event": "user_created_or_updated_segment",
     "app_name": "Test",
     "app_ver": "1.0",
     "os_name": "ios",

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -47,7 +47,7 @@
   "output": {
     "dev_id": "999999",
     "events": "[{\"event\":\"Damn Daniel\",\"time\":1451606400,\"properties\":{\"shoes\":[\"White Vans\"]}}]",
-    "credentials": "{\"user_id\":\"111\",\"email\":\"bulgogi@bulgogi.com\",\"username\":\"food\"}",
+    "credentials": "{\"user_id\":\"111\",\"email\":\"bulgogi@bulgogi.com\"}",
     "user_info": "{\"firstName\":\"Han\",\"lastName\":\"Kim\",\"email\":\"bulgogi@bulgogi.com\",\"username\":\"food\",\"id\":\"111\"}",
     "app_name": "Test",
     "app_ver": "1.0",

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -1,11 +1,14 @@
 {
   "input": {
     "type": "track",
-    "timestamp": "2014",
-    "event": "played a song",
-    "userId": "user-id2",
+    "timestamp": "2016",
+    "event": "Damn Daniel",
+    "userId": "111",
+    "properties": {
+      "shoes": "White Vans"
+    },
     "context": {
-      "ip": "10.0.0.2",
+     "ip": "10.0.0.2",
       "app": {
         "name": "Test",
         "version": "1.0"
@@ -15,10 +18,10 @@
         "model": "1.2",
         "manufacturer": "some-brand",
         "advertisingId": "id-for-attribution",
-        "id": "some-device"
+        "id": "999999"
       },
       "os": {
-        "name": "ios",
+        "name": "Android",
         "version": "7.0"
       },
       "network": {
@@ -34,23 +37,21 @@
         "id": "some-id"
       },
       "traits": {
-        "firstName": "Jane",
-        "lastName": "Doe",
-        "email": "janedoe@example.com",
-        "username": "janedoe23"
+        "firstName": "Han",
+        "lastName": "Kim",
+        "email": "bulgogi@bulgogi.com",
+        "username": "food"
       }
     }
   },
   "output": {
-    "dev_id": "some-device",
-    "user_id": "user-id2",
-    "user_email": "janedoe@example.com",
-    "user_info": "{\"firstName\":\"Jane\",\"lastName\":\"Doe\",\"email\":\"janedoe@example.com\",\"username\":\"janedoe23\"}",
-    "username": "janedoe23",
-    "event": "played a song",
+    "dev_id": "999999",
+    "events": "[{\"event\":\"Damn Daniel\",\"time\":1451606400,\"properties\":{\"shoes\":[\"White Vans\"]}}]",
+    "credentials": "{\"user_id\":\"111\",\"email\":\"bulgogi@bulgogi.com\",\"username\":\"food\"}",
+    "user_info": "{\"firstName\":\"Han\",\"lastName\":\"Kim\",\"email\":\"bulgogi@bulgogi.com\",\"username\":\"food\",\"id\":\"111\"}",
     "app_name": "Test",
     "app_ver": "1.0",
-    "os_name": "ios",
+    "os_name": "android",
     "os_version": "7.0",
     "dev_name": "1.2"
   }

--- a/test/fixtures/track-no-dev-id-email.json
+++ b/test/fixtures/track-no-dev-id-email.json
@@ -41,10 +41,9 @@
   },
   "output": {
     "dev_id": "nodev-segment-3040054890",
-    "user_email": "janedoe@example.com",
+    "credentials": "{\"email\":\"janedoe@example.com\"}",
     "user_info": "{\"firstName\":\"Jane\",\"lastName\":\"Doe\",\"email\":\"janedoe@example.com\",\"username\":\"janedoe23\"}",
-    "username": "janedoe23",
-    "event": "played a song",
+    "events": "[{\"event\":\"played a song\",\"time\":1388534400,\"properties\":{}}]",
     "app_name": "Test",
     "app_ver": "1.0",
     "os_version": "7.0",

--- a/test/fixtures/track-no-dev-id-user-id.json
+++ b/test/fixtures/track-no-dev-id-user-id.json
@@ -41,10 +41,9 @@
   },
   "output": {
     "dev_id": "nodev-segment-user-id-3076010732",
-    "user_id": "user-id-5",
-    "user_email": "janedoe@example.com",
-    "user_info": "{\"firstName\":\"Jane\",\"lastName\":\"Doe\",\"email\":\"janedoe@example.com\"}",
-    "event": "played a song",
+    "credentials": "{\"user_id\":\"user-id-5\",\"email\":\"janedoe@example.com\"}",
+    "user_info": "{\"firstName\":\"Jane\",\"lastName\":\"Doe\",\"email\":\"janedoe@example.com\",\"id\":\"user-id-5\"}",
+    "events": "[{\"event\":\"played a song\",\"time\":1388534400,\"properties\":{}}]",
     "app_name": "Test",
     "app_ver": "1.0",
     "os_version": "7.0",

--- a/test/fixtures/track-notraits.json
+++ b/test/fixtures/track-notraits.json
@@ -1,9 +1,12 @@
 {
   "input": {
     "type": "track",
-    "timestamp": "2014",
-    "event": "played a song",
-    "userId": "user-id2",
+    "timestamp": "2016",
+    "event": "Back at it again",
+    "properties": {
+      "mood": "thirsty man"
+    },
+    "userId": "111",
     "context": {
       "ip": "10.0.0.2",
       "app": {
@@ -15,7 +18,7 @@
         "model": "1.2",
         "manufacturer": "some-brand",
         "advertisingId": "id-for-attribution",
-        "id": "some-device"
+        "id": "999999"
       },
       "os": {
         "name": "android",
@@ -36,9 +39,9 @@
     }
   },
   "output": {
-    "dev_id": "some-device",
-    "user_id": "user-id2",
-    "event": "played a song",
+    "dev_id": "999999",
+    "credentials": "{\"user_id\":\"111\"}",
+    "events": "[{\"event\":\"Back at it again\",\"time\":1451606400,\"properties\":{\"mood\":[\"thirsty man\"]}}]",
     "app_name": "Test",
     "app_ver": "1.0",
     "os_name": "android",

--- a/test/index.js
+++ b/test/index.js
@@ -42,6 +42,10 @@ describe('Kahuna', function(){
       it('should map basic identify', function(){
         test.maps('identify-basic');
       });
+
+      it('should map identify even with no device.id', function(){
+        test.maps('identify-no-dev-id');
+      });
     });
 
     describe('track', function(){
@@ -55,35 +59,35 @@ describe('Kahuna', function(){
     });
   });
 
-  describe('.identify()', function(){
-    it('should send basic identify', function(done){
-      var json = test.fixture('identify-basic');
+  // describe('.identify()', function(){
+  //   it('should send basic identify', function(done){
+  //     var json = test.fixture('identify-basic');
 
-      json.output.key = settings.apiKey;
-      json.output.env = settings.env ? 'p' : 's';
+  //     json.output.key = settings.apiKey;
+  //     json.output.env = settings.env ? 'p' : 's';
 
-      var output = json.output;
-      test
-        .identify(json.input)
-        .sends(json.output)
-        .expects(200)
-        .end(done);
-    });
+  //     var output = json.output;
+  //     test
+  //       .identify(json.input)
+  //       .sends(json.output)
+  //       .expects(200)
+  //       .end(done);
+  //   });
 
-    it('identify should have dev_id', function(done){
-      var json = test.fixture('identify-no-dev-id');
+  //   it('identify should have dev_id', function(done){
+  //     var json = test.fixture('identify-no-dev-id');
 
-      json.output.key = settings.apiKey;
-      json.output.env = settings.env ? 'p' : 's';
+  //     json.output.key = settings.apiKey;
+  //     json.output.env = settings.env ? 'p' : 's';
 
-      var output = json.output;
-      test
-        .identify(json.input)
-        .sends(json.output)
-        .expects(200)
-        .end(done);
-    });
-  });
+  //     var output = json.output;
+  //     test
+  //       .identify(json.input)
+  //       .sends(json.output)
+  //       .expects(200)
+  //       .end(done);
+  //   });
+  // });
 
   describe('.track()', function(){
     it('should send basic track', function(done){
@@ -112,30 +116,30 @@ describe('Kahuna', function(){
         .end(done);
     });
 
-    it('should have dev_id with user_id', function(done){
-      var json = test.fixture('track-no-dev-id-user-id');
+    // it('should have dev_id with user_id', function(done){
+    //   var json = test.fixture('track-no-dev-id-user-id');
 
-      json.output.key = settings.apiKey;
-      json.output.env = settings.env ? 'p' : 's';
+    //   json.output.key = settings.apiKey;
+    //   json.output.env = settings.env ? 'p' : 's';
 
-      test
-        .track(json.input)
-        .sends(json.output)
-        .expects(200)
-        .end(done);
-    });
+    //   test
+    //     .track(json.input)
+    //     .sends(json.output)
+    //     .expects(200)
+    //     .end(done);
+    // });
 
-    it('should have dev_id with email', function(done){
-      var json = test.fixture('track-no-dev-id-email');
+    // it('should have dev_id with email', function(done){
+    //   var json = test.fixture('track-no-dev-id-email');
 
-      json.output.key = settings.apiKey;
-      json.output.env = settings.env ? 'p' : 's';
+    //   json.output.key = settings.apiKey;
+    //   json.output.env = settings.env ? 'p' : 's';
 
-      test
-        .track(json.input)
-        .sends(json.output)
-        .expects(200)
-        .end(done);
-    });
+    //   test
+    //     .track(json.input)
+    //     .sends(json.output)
+    //     .expects(200)
+    //     .end(done);
+    // });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -59,35 +59,35 @@ describe('Kahuna', function(){
     });
   });
 
-  // describe('.identify()', function(){
-  //   it('should send basic identify', function(done){
-  //     var json = test.fixture('identify-basic');
+  describe('.identify()', function(){
+    it('should send basic identify', function(done){
+      var json = test.fixture('identify-basic');
 
-  //     json.output.key = settings.apiKey;
-  //     json.output.env = settings.env ? 'p' : 's';
+      json.output.key = settings.apiKey;
+      json.output.env = settings.env ? 'p' : 's';
 
-  //     var output = json.output;
-  //     test
-  //       .identify(json.input)
-  //       .sends(json.output)
-  //       .expects(200)
-  //       .end(done);
-  //   });
+      var output = json.output;
+      test
+        .identify(json.input)
+        .sends(json.output)
+        .expects(200)
+        .end(done);
+    });
 
-  //   it('identify should have dev_id', function(done){
-  //     var json = test.fixture('identify-no-dev-id');
+    it('identify should have dev_id', function(done){
+      var json = test.fixture('identify-no-dev-id');
 
-  //     json.output.key = settings.apiKey;
-  //     json.output.env = settings.env ? 'p' : 's';
+      json.output.key = settings.apiKey;
+      json.output.env = settings.env ? 'p' : 's';
 
-  //     var output = json.output;
-  //     test
-  //       .identify(json.input)
-  //       .sends(json.output)
-  //       .expects(200)
-  //       .end(done);
-  //   });
-  // });
+      var output = json.output;
+      test
+        .identify(json.input)
+        .sends(json.output)
+        .expects(200)
+        .end(done);
+    });
+  });
 
   describe('.track()', function(){
     it('should send basic track', function(done){
@@ -116,30 +116,30 @@ describe('Kahuna', function(){
         .end(done);
     });
 
-    // it('should have dev_id with user_id', function(done){
-    //   var json = test.fixture('track-no-dev-id-user-id');
+    it('should have dev_id with user_id', function(done){
+      var json = test.fixture('track-no-dev-id-user-id');
 
-    //   json.output.key = settings.apiKey;
-    //   json.output.env = settings.env ? 'p' : 's';
+      json.output.key = settings.apiKey;
+      json.output.env = settings.env ? 'p' : 's';
 
-    //   test
-    //     .track(json.input)
-    //     .sends(json.output)
-    //     .expects(200)
-    //     .end(done);
-    // });
+      test
+        .track(json.input)
+        .sends(json.output)
+        .expects(200)
+        .end(done);
+    });
 
-    // it('should have dev_id with email', function(done){
-    //   var json = test.fixture('track-no-dev-id-email');
+    it('should have dev_id with email', function(done){
+      var json = test.fixture('track-no-dev-id-email');
 
-    //   json.output.key = settings.apiKey;
-    //   json.output.env = settings.env ? 'p' : 's';
+      json.output.key = settings.apiKey;
+      json.output.env = settings.env ? 'p' : 's';
 
-    //   test
-    //     .track(json.input)
-    //     .sends(json.output)
-    //     .expects(200)
-    //     .end(done);
-    // });
+      test
+        .track(json.input)
+        .sends(json.output)
+        .expects(200)
+        .end(done);
+    });
   });
 });


### PR DESCRIPTION
Okay so we were not sending user data and track events in accordance to [Kahuna's Docs](https://app.usekahuna.com/tap/public_docs/Content/APIs/Server.htm#).

I also got on call with 4 of their engineers to comb through this PR. They gave it a green light. 

I added a lot of in line comments for why I'm doing certain things. 

**Notable Changes**
- Removal of `username` was requested by Kahuna. I think we originally thought this was an important trait to send to Kahuna but they said it doesn't do anything really. They also said it won't break reports.

- Changing the name of the event to from `start` to `user_created_or_updated_segment` was also requested by Kahuna since the name doesn't really have any meaning or feature dependency and doesn't break reports since these are `.identify()` calls. 

- One key thing is that we are using [Kahuna's Intelligent Events](https://app.usekahuna.com/tap/public_docs/Content/APIs/Server.htm#Intelligent_Event_Request) feature for `.track()` calls which is only available via their `REST` api and NOT with the mobile SDKs. 

So that should be noted in our docs. 

Let me know what you guys think. I'd like to get this merged by end of Friday and then deployed next Monday :)

@sperand-io @f2prateek 

