### PR TITLE
stringify properties for intelligent events

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -87,15 +87,14 @@ function addDeviceParams(facade, payload) {
   payload.app_ver = facade.proxy('context.app.version');
 
   // os props
-  payload.os_name = facade.proxy('context.os.name');
+  if (facade.proxy('context.os.name')) payload.os_name = facade.proxy('context.os.name').toLowerCase();
+
   // Preserve `ios` or `android` if that's what the client sent.
-  // Note: comparisons are case sensitive, so `iOS` would actually be rejected.
   if (payload.os_name !== 'ios' && payload.os_name !== 'android') {
     // Try to coerce it to the appropriate platform.
-    if (payload.os_name === 'iPhone OS') {
+    // Can let android just pass through since it is same string
+    if (payload.os_name === 'iphone os') {
       payload.os_name = 'ios';
-    } else if (payload.os_name === 'Android') {
-      payload.os_name = 'android';
     } else {
       // don't send anything if it's not `Android` or `iPhone OS`.
       // Kahuna will record it as a `web` user on their end.

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -54,9 +54,9 @@ exports.track = function(track){
   }];
 
   // Formulate properties to required specs
-  // TODO handle nested objects and arrays
+  // TODO handle nested objects and arrays by flattening
   events[0].properties = foldl(function(results, value, key){
-    results[key] = [value];
+    if (value) results[key] = [value.toString()]; // they do not accept any other data type
     return results;
   }, {}, track.properties());
 

--- a/test/fixtures/identify-basic.json
+++ b/test/fixtures/identify-basic.json
@@ -1,11 +1,11 @@
 {
   "input": {
     "type": "identify",
-    "userId": "111",
+    "userId": "coconut1234",
     "traits": {
       "firstName": "Han",
       "lastName": "Kim",
-      "email": "bulgogi@bulgogi.com",
+      "email": "water@water.com",
       "username": "food"
     },
     "context": {
@@ -19,7 +19,7 @@
         "model": "1.2",
         "manufacturer": "some-brand",
         "advertisingId": "id-for-attribution",
-        "id": "999999"
+        "id": "88838643"
       },
       "os": {
         "name": "Android",
@@ -40,9 +40,9 @@
     }
   },
   "output": {
-    "dev_id": "999999",
-    "credentials": "{\"user_id\":\"111\",\"email\":\"bulgogi@bulgogi.com\"}",
-    "user_info": "{\"firstName\":\"Han\",\"lastName\":\"Kim\",\"email\":\"bulgogi@bulgogi.com\",\"username\":\"food\",\"id\":\"111\"}",
+    "dev_id": "88838643",
+    "credentials": "{\"user_id\":\"coconut1234\",\"email\":\"water@water.com\"}",
+    "user_info": "{\"firstName\":\"Han\",\"lastName\":\"Kim\",\"email\":\"water@water.com\",\"username\":\"food\",\"id\":\"coconut1234\"}",
     "event": "user_created_or_updated_segment",
     "app_name": "Test",
     "app_ver": "1.0",

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -3,7 +3,7 @@
     "type": "track",
     "timestamp": "2016",
     "event": "Damn Daniel",
-    "userId": "111",
+    "userId": "coconut1234",
     "properties": {
       "shoes": "White Vans"
     },
@@ -18,7 +18,7 @@
         "model": "1.2",
         "manufacturer": "some-brand",
         "advertisingId": "id-for-attribution",
-        "id": "999999"
+        "id": "88838643"
       },
       "os": {
         "name": "Android",
@@ -39,16 +39,16 @@
       "traits": {
         "firstName": "Han",
         "lastName": "Kim",
-        "email": "bulgogi@bulgogi.com",
+        "email": "water@water.com",
         "username": "food"
       }
     }
   },
   "output": {
-    "dev_id": "999999",
+    "dev_id": "88838643",
     "events": "[{\"event\":\"Damn Daniel\",\"time\":1451606400,\"properties\":{\"shoes\":[\"White Vans\"]}}]",
-    "credentials": "{\"user_id\":\"111\",\"email\":\"bulgogi@bulgogi.com\"}",
-    "user_info": "{\"firstName\":\"Han\",\"lastName\":\"Kim\",\"email\":\"bulgogi@bulgogi.com\",\"username\":\"food\",\"id\":\"111\"}",
+    "credentials": "{\"user_id\":\"coconut1234\",\"email\":\"water@water.com\"}",
+    "user_info": "{\"firstName\":\"Han\",\"lastName\":\"Kim\",\"email\":\"water@water.com\",\"username\":\"food\",\"id\":\"coconut1234\"}",
     "app_name": "Test",
     "app_ver": "1.0",
     "os_name": "android",

--- a/test/fixtures/track-full.json
+++ b/test/fixtures/track-full.json
@@ -5,7 +5,10 @@
     "event": "Damn Daniel",
     "userId": "111",
     "properties": {
-      "shoes": "White Vans"
+      "shoes": "White Vans",
+      "boolean": true,
+      "number": 3,
+      "shouldNotBeIncluded": null
     },
     "context": {
      "ip": "10.0.0.2",
@@ -46,7 +49,7 @@
   },
   "output": {
     "dev_id": "999999",
-    "events": "[{\"event\":\"Damn Daniel\",\"time\":1451606400,\"properties\":{\"shoes\":[\"White Vans\"]}}]",
+    "events": "[{\"event\":\"Damn Daniel\",\"time\":1451606400,\"properties\":{\"shoes\":[\"White Vans\"],\"boolean\":[\"true\"],\"number\":[\"3\"]}}]",
     "credentials": "{\"user_id\":\"111\",\"email\":\"bulgogi@bulgogi.com\"}",
     "user_info": "{\"firstName\":\"Han\",\"lastName\":\"Kim\",\"email\":\"bulgogi@bulgogi.com\",\"username\":\"food\",\"id\":\"111\"}",
     "app_name": "Test",

--- a/test/fixtures/track-no-dev-id-email.json
+++ b/test/fixtures/track-no-dev-id-email.json
@@ -1,7 +1,7 @@
 {
   "input": {
     "type": "track",
-    "timestamp": "2014",
+    "timestamp": "2016",
     "event": "played a song",
     "context": {
       "ip": "10.0.0.2",
@@ -16,7 +16,7 @@
         "advertisingId": "id-for-attribution"
       },
       "os": {
-        "name": "iOS",
+        "name": "iPhone OS",
         "version": "7.0"
       },
       "network": {
@@ -43,9 +43,10 @@
     "dev_id": "nodev-segment-3040054890",
     "credentials": "{\"email\":\"janedoe@example.com\"}",
     "user_info": "{\"firstName\":\"Jane\",\"lastName\":\"Doe\",\"email\":\"janedoe@example.com\",\"username\":\"janedoe23\"}",
-    "events": "[{\"event\":\"played a song\",\"time\":1388534400,\"properties\":{}}]",
+    "events": "[{\"event\":\"played a song\",\"time\":1451606400,\"properties\":{}}]",
     "app_name": "Test",
     "app_ver": "1.0",
+    "os_name": "ios",
     "os_version": "7.0",
     "dev_name": "1.2"
   }

--- a/test/fixtures/track-no-dev-id-user-id.json
+++ b/test/fixtures/track-no-dev-id-user-id.json
@@ -1,7 +1,7 @@
 {
   "input": {
     "type": "track",
-    "timestamp": "2014",
+    "timestamp": "2016",
     "event": "played a song",
     "userId": "user-id-5",
     "context": {
@@ -17,7 +17,7 @@
         "advertisingId": "id-for-attribution"
       },
       "os": {
-        "name": "OSX",
+        "name": "iPhone OS",
         "version": "7.0"
       },
       "network": {
@@ -43,9 +43,10 @@
     "dev_id": "nodev-segment-user-id-3076010732",
     "credentials": "{\"user_id\":\"user-id-5\",\"email\":\"janedoe@example.com\"}",
     "user_info": "{\"firstName\":\"Jane\",\"lastName\":\"Doe\",\"email\":\"janedoe@example.com\",\"id\":\"user-id-5\"}",
-    "events": "[{\"event\":\"played a song\",\"time\":1388534400,\"properties\":{}}]",
+    "events": "[{\"event\":\"played a song\",\"time\":1451606400,\"properties\":{}}]",
     "app_name": "Test",
     "app_ver": "1.0",
+    "os_name": "ios",
     "os_version": "7.0",
     "dev_name": "1.2"
   }

--- a/test/fixtures/track-notraits.json
+++ b/test/fixtures/track-notraits.json
@@ -21,7 +21,7 @@
         "id": "999999"
       },
       "os": {
-        "name": "android",
+        "name": "Android",
         "version": "7.0"
       },
       "network": {

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,10 @@ describe('Kahuna', function(){
         test.maps('track-basic');
       });
 
+      it('should map full track', function(){
+        test.maps('track-full');
+      });
+
       it('should map notraits track', function(){
         test.maps('track-notraits');
       });


### PR DESCRIPTION
So last time we deployed this, it caused an outage because we were not stringifying every data type inside the `properties` field when sending `.track()` events to Kahuna's [Intelligent Events](https://app.usekahuna.com/tap/public_docs/Content/APIs/Server.htm#Intelligent_Event_Request) endpoint.

I've confirmed with their engineers that this is the right away. They want everything stringified otherwise, they will reject the message and return a 4xx. 

The next PR will be handling compound objects such as nested obj & arrays. Wanted to keep that to a separate PR.

@f2prateek @sperand-io @ndhoule @thehydroimpulse @wcjohnson11 